### PR TITLE
added network fee component and added to trade and streams

### DIFF
--- a/frontend/app/components/home/detailSection/index.tsx
+++ b/frontend/app/components/home/detailSection/index.tsx
@@ -5,6 +5,8 @@ import { ReserveData } from '@/app/lib/dex/calculators'
 import { formatEther } from 'ethers/lib/utils'
 import { Skeleton } from '@/components/ui/skeleton'
 import DexSummary from './DexSummary'
+import { useCoreTrading } from '@/app/lib/hooks/useCoreTrading'
+import NetworkFee from '../../shared/NetworkFee'
 
 interface DetailSectionProps {
   sellAmount?: string
@@ -40,6 +42,14 @@ const DetailSection: React.FC<DetailSectionProps> = ({
   isFetchingReserves = false,
 }) => {
   const [showDetails, setShowDetails] = useState(true)
+  const { contractInfo, getContractInfo } = useCoreTrading()
+
+  // Fetch contract info on component mount if not already available
+  useEffect(() => {
+    if (!contractInfo) {
+      getContractInfo()
+    }
+  }, [contractInfo, getContractInfo])
 
   const toggleDetails = () => setShowDetails(!showDetails)
 
@@ -222,6 +232,13 @@ const DetailSection: React.FC<DetailSectionProps> = ({
             amount={isCalculating ? undefined : formatSlippageSavings()}
             infoDetail="Estimated"
             isLoading={isCalculating}
+          />
+          <NetworkFee
+            buyAmount={buyAmount}
+            tokenToUsdPrice={tokenToUsdPrice}
+            tokenToSymbol={tokenToSymbol}
+            contractInfo={contractInfo}
+            isCalculating={isCalculating}
           />
           {/* <AmountTag
             title="Price Impact"

--- a/frontend/app/components/shared/NetworkFee.tsx
+++ b/frontend/app/components/shared/NetworkFee.tsx
@@ -1,0 +1,68 @@
+import React from 'react'
+import AmountTag from '../amountTag'
+
+interface NetworkFeeProps {
+  buyAmount?: string
+  tokenToUsdPrice?: number
+  tokenToSymbol?: string
+  contractInfo?: {
+    streamProtocolFeeBps: string | number
+    streamBotFeeBps: string | number
+  } | null
+  isCalculating?: boolean
+  titleClassName?: string
+}
+
+const NetworkFee: React.FC<NetworkFeeProps> = ({
+  buyAmount,
+  tokenToUsdPrice,
+  tokenToSymbol,
+  contractInfo,
+  isCalculating = false,
+  titleClassName,
+}) => {
+  // Calculate dynamic network fee from contract
+  const getNetworkFeeBps = () => {
+    if (contractInfo) {
+      const streamProtocolFeeBps = Number(contractInfo.streamProtocolFeeBps)
+      const streamBotFeeBps = Number(contractInfo.streamBotFeeBps)
+      return streamProtocolFeeBps + streamBotFeeBps
+    }
+    // Fallback to hardcoded value if contract info not available
+    return 20 // 20 basis points as fallback
+  }
+
+  // Calculate network fee amount - calculated on output token
+  const calculateNetworkFee = () => {
+    const networkFeeBps = getNetworkFeeBps()
+
+    if (!buyAmount || !tokenToUsdPrice || isCalculating) {
+      return `${networkFeeBps} BPS${tokenToSymbol ? ` ${tokenToSymbol}` : ''}`
+    }
+
+    const numericBuyAmount = parseFloat(buyAmount)
+    if (isNaN(numericBuyAmount)) {
+      return `${networkFeeBps} BPS${tokenToSymbol ? ` ${tokenToSymbol}` : ''}`
+    }
+
+    // Calculate fee in token amount (buyAmount is in output token units)
+    const networkFeeInToken = numericBuyAmount * (networkFeeBps / 10000)
+    const networkFeeUsd = networkFeeInToken * tokenToUsdPrice
+
+    return `${networkFeeBps} BPS ${
+      tokenToSymbol || ''
+    } ($${networkFeeUsd.toFixed(2)})`
+  }
+
+  return (
+    <AmountTag
+      title="Network Fee"
+      amount={isCalculating ? undefined : calculateNetworkFee()}
+      infoDetail="Estimated"
+      isLoading={isCalculating}
+      titleClassName={titleClassName}
+    />
+  )
+}
+
+export default NetworkFee

--- a/frontend/app/components/streamDetails/index.tsx
+++ b/frontend/app/components/streamDetails/index.tsx
@@ -18,6 +18,8 @@ import { cn } from '@/lib/utils'
 import { ArrowLeft, X } from 'lucide-react'
 import { useWallet } from '@/app/lib/hooks/useWallet'
 import { useCoreTrading } from '@/app/lib/hooks/useCoreTrading'
+import { useEffect } from 'react'
+import NetworkFee from '../shared/NetworkFee'
 
 type StreamDetailsProps = {
   onBack: () => void
@@ -41,8 +43,22 @@ const StreamDetails: React.FC<StreamDetailsProps> = ({
   walletAddress,
 }) => {
   const { tokens, isLoading: isLoadingTokens } = useTokenList()
-  const { placeTrade, loading, instasettle, cancelTrade } = useCoreTrading()
+  const {
+    placeTrade,
+    loading,
+    instasettle,
+    cancelTrade,
+    contractInfo,
+    getContractInfo,
+  } = useCoreTrading()
   const { getSigner, isConnected: isConnectedWallet } = useWallet()
+
+  // Fetch contract info on component mount if not already available
+  useEffect(() => {
+    if (!contractInfo) {
+      getContractInfo()
+    }
+  }, [contractInfo, getContractInfo])
 
   if (!selectedStream) {
     return null
@@ -167,16 +183,6 @@ const StreamDetails: React.FC<StreamDetailsProps> = ({
     : '0'
   const swappedAmountInUsd = tokenIn
     ? Number(swappedAmountIn) * (tokenIn.usd_price || 0)
-    : 0
-
-  const NETWORK_FEE_BPS = 5 // 5 basis points
-
-  const networkFeeInToken = tokenIn
-    ? Number(formatUnits(BigInt(selectedStream.amountIn), tokenIn.decimals)) *
-      (NETWORK_FEE_BPS / 10000)
-    : 0
-  const networkFeeUsd = tokenIn
-    ? networkFeeInToken * (tokenIn.usd_price || 0)
     : 0
 
   const handleInstasettleClick = async (item: any) => {
@@ -567,12 +573,13 @@ const StreamDetails: React.FC<StreamDetailsProps> = ({
               titleClassName="text-white52"
               isLoading={isLoading}
             /> */}
-            <AmountTag
-              title="Network Fee"
-              amount={`5 BPS ($${networkFeeUsd.toFixed(2)})`}
-              infoDetail="Info"
+            <NetworkFee
+              buyAmount={formattedMinAmountOut}
+              tokenToUsdPrice={tokenOut?.usd_price}
+              tokenToSymbol={tokenOut?.symbol}
+              contractInfo={contractInfo}
+              isCalculating={isLoading}
               titleClassName="text-white52"
-              isLoading={isLoading}
             />
             <AmountTag
               title="Wallet Address"


### PR DESCRIPTION
Added Network fee component to the trade window and Ongoing trade stream summary. 
Fetching BPS from the contract (streamBotFeeBps(10) + streamProtocolFeeBps (10) ) = 20 

defaulting to 20 if we cant get it from the contract

<img width="1214" height="895" alt="image" src="https://github.com/user-attachments/assets/6d5834dc-d294-4b02-bf32-f11796cdec32" />
