### PR TITLE
Number formating implemented and handle two lines on streamdetails

### DIFF
--- a/frontend/app/components/home/detailSection/index.tsx
+++ b/frontend/app/components/home/detailSection/index.tsx
@@ -5,7 +5,7 @@ import { ReserveData } from '@/app/lib/dex/calculators'
 import { formatEther } from 'ethers/lib/utils'
 import { Skeleton } from '@/components/ui/skeleton'
 import DexSummary from './DexSummary'
-import { formatNumberWithSubscript } from '@/app/lib/utils/number'
+import { formatNumberSmart } from '@/app/lib/utils/number'
 
 interface DetailSectionProps {
   sellAmount?: string
@@ -137,7 +137,7 @@ const DetailSection: React.FC<DetailSectionProps> = ({
             />
           )}
           <p>
-            {formatNumberWithSubscript(sellAmount)} {tokenFromSymbol}
+            {formatNumberSmart(sellAmount)} {tokenFromSymbol}
           </p>
           {inValidAmount ? (
             <Image
@@ -160,7 +160,7 @@ const DetailSection: React.FC<DetailSectionProps> = ({
             {isCalculating ? (
               <LoadingSkeleton />
             ) : (
-              `${formatNumberWithSubscript(buyAmount)} ${tokenToSymbol} (Est)`
+              `${formatNumberSmart(buyAmount)} ${tokenToSymbol} (Est)`
             )}
           </p>
         </div>

--- a/frontend/app/components/streamDetails/index.tsx
+++ b/frontend/app/components/streamDetails/index.tsx
@@ -18,7 +18,7 @@ import { cn } from '@/lib/utils'
 import { ArrowLeft, X } from 'lucide-react'
 import { useWallet } from '@/app/lib/hooks/useWallet'
 import { useCoreTrading } from '@/app/lib/hooks/useCoreTrading'
-import { formatNumberWithSubscript } from '@/app/lib/utils/number'
+import { formatNumberSmart } from '@/app/lib/utils/number'
 import { calculateRemainingStreams } from '@/app/lib/utils/streams'
 import { useState } from 'react'
 
@@ -502,8 +502,7 @@ const StreamDetails: React.FC<StreamDetailsProps> = ({
               ) : (
                 <>
                   <p className="text-white">
-                    {formatNumberWithSubscript(formattedAmountIn)}{' '}
-                    {tokenIn?.symbol}
+                    {formatNumberSmart(formattedAmountIn)} {tokenIn?.symbol}
                   </p>
                   <p className="text-white52 text-[14px]">
                     ${amountInUsd.toFixed(2)}
@@ -520,7 +519,7 @@ const StreamDetails: React.FC<StreamDetailsProps> = ({
               ) : (
                 <>
                   <p className="text-white">
-                    ~ {formatNumberWithSubscript(formattedMinAmountOut)}{' '}
+                    ~ {formatNumberSmart(formattedMinAmountOut)}{' '}
                     {tokenOut?.symbol}
                   </p>
                   <p className="text-white52 text-[14px]">
@@ -605,10 +604,10 @@ const StreamDetails: React.FC<StreamDetailsProps> = ({
                 <>
                   <p className="">
                     {showCompleted
-                      ? `${formatNumberWithSubscript(formattedSwapAmountOut)} ${
+                      ? `${formatNumberSmart(formattedSwapAmountOut)} ${
                           tokenOut?.symbol
                         }`
-                      : `~ ${formatNumberWithSubscript(remainingAmountOut)} ${
+                      : `~ ${formatNumberSmart(remainingAmountOut)} ${
                           tokenOut?.symbol
                         }`}
                   </p>

--- a/frontend/app/components/swapStream/index.tsx
+++ b/frontend/app/components/swapStream/index.tsx
@@ -11,7 +11,7 @@ import { cn } from '@/lib/utils'
 import { useStreamTime } from '@/app/lib/hooks/useStreamTime'
 import ImageFallback from '@/app/shared/ImageFallback'
 import { XIcon } from 'lucide-react'
-import { formatNumberWithSubscript } from '@/app/lib/utils/number'
+import { formatNumberSmart } from '@/app/lib/utils/number'
 import { calculateRemainingStreams } from '@/app/lib/utils/streams'
 
 type Trade = {
@@ -125,8 +125,7 @@ const SwapStream: React.FC<Props> = ({ trade, onClick, isUser, isLoading }) => {
                   className="w-[18px] h-[18px] rounded-full overflow-hidden"
                 />
                 <p className="text-white uppercase">
-                  {formatNumberWithSubscript(formattedAmountIn)}{' '}
-                  {tokenIn?.symbol}
+                  {formatNumberSmart(formattedAmountIn)} {tokenIn?.symbol}
                 </p>
               </>
             )}
@@ -158,8 +157,8 @@ const SwapStream: React.FC<Props> = ({ trade, onClick, isUser, isLoading }) => {
                   className="w-[18px] h-[18px] rounded-full overflow-hidden"
                 />
                 <p className="text-white uppercase">
-                  {formatNumberWithSubscript(formattedMinAmountOut)}{' '}
-                  {tokenOut?.symbol} (EST)
+                  {formatNumberSmart(formattedMinAmountOut)} {tokenOut?.symbol}{' '}
+                  (EST)
                 </p>
               </>
             )}
@@ -193,7 +192,7 @@ const SwapStream: React.FC<Props> = ({ trade, onClick, isUser, isLoading }) => {
 
         <div
           className={cn(
-            'flex justify-between items-center gap-2 text-white52',
+            'flex flex-wrap items-center gap-x-2 gap-y-1 text-white52',
             isLoading ? 'mt-3.5' : 'mt-1.5'
           )}
         >
@@ -207,7 +206,7 @@ const SwapStream: React.FC<Props> = ({ trade, onClick, isUser, isLoading }) => {
             </>
           ) : (
             <>
-              <p className="">
+              <p className="whitespace-nowrap">
                 {trade.settlements.length > 0
                   ? trade.settlements.length + trade.executions.length
                   : trade.executions.length}{' '}
@@ -217,55 +216,53 @@ const SwapStream: React.FC<Props> = ({ trade, onClick, isUser, isLoading }) => {
                   : remainingStreams}{' '}
                 completed
               </p>
-              <div className="flex gap-2">
-                {trade.settlements.length > 0 ||
-                trade.cancellations.length > 0 ? (
-                  ''
-                ) : (
-                  <div className="flex items-center">
-                    <Image
-                      src="/icons/time.svg"
-                      alt="clock"
-                      className="w-5"
-                      width={20}
-                      height={20}
+              {trade.settlements.length > 0 ||
+              trade.cancellations.length > 0 ? (
+                ''
+              ) : (
+                <div className="flex items-center whitespace-nowrap ml-auto">
+                  <Image
+                    src="/icons/time.svg"
+                    alt="clock"
+                    className="w-5"
+                    width={20}
+                    height={20}
+                  />
+                  <p>{estimatedTime || '..'}</p>
+                </div>
+              )}
+              {trade.isInstasettlable && (
+                <div className="flex items-center text-sm gap-1 bg-zinc-900 pl-1 pr-1.5 text-primary rounded-full leading-none whitespace-nowrap ml-auto">
+                  <svg
+                    width="20"
+                    height="20"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    xmlns="http://www.w3.org/2000/svg"
+                    className="w-4 h-4 sm:w-5 sm:h-5"
+                  >
+                    <path
+                      d="M13 2L6 14H11V22L18 10H13V2Z"
+                      fill="#40f798"
+                      fillOpacity="0.72"
                     />
-                    <p>{estimatedTime || '..'}</p>
-                  </div>
-                )}
-                {trade.isInstasettlable && (
-                  <div className="flex items-center text-sm gap-1 bg-zinc-900 pl-1 pr-1.5 text-primary rounded-full leading-none">
-                    <svg
-                      width="20"
-                      height="20"
-                      viewBox="0 0 24 24"
-                      fill="none"
-                      xmlns="http://www.w3.org/2000/svg"
-                      className="w-4 h-4 sm:w-5 sm:h-5"
-                    >
-                      <path
-                        d="M13 2L6 14H11V22L18 10H13V2Z"
-                        fill="#40f798"
-                        fillOpacity="0.72"
-                      />
-                    </svg>
-                    <span className="text-xs sm:inline-block hidden">
-                      {trade.settlements.length > 0
-                        ? 'Instasettled'
-                        : 'Instasettle'}
-                    </span>
-                  </div>
-                )}
+                  </svg>
+                  <span className="text-xs sm:inline-block hidden">
+                    {trade.settlements.length > 0
+                      ? 'Instasettled'
+                      : 'Instasettle'}
+                  </span>
+                </div>
+              )}
 
-                {trade.cancellations.length > 0 && (
-                  <div className="flex items-center text-sm gap-1 bg-zinc-900 pl-1 pr-1.5 text-red-700 rounded-full leading-none">
-                    <XIcon className="w-3.5 h-3.5" />
-                    <span className="text-xs sm:inline-block hidden">
-                      Cancelled
-                    </span>
-                  </div>
-                )}
-              </div>
+              {trade.cancellations.length > 0 && (
+                <div className="flex items-center text-sm gap-1 bg-zinc-900 pl-1 pr-1.5 text-red-700 rounded-full leading-none whitespace-nowrap ml-auto">
+                  <XIcon className="w-3.5 h-3.5" />
+                  <span className="text-xs sm:inline-block hidden">
+                    Cancelled
+                  </span>
+                </div>
+              )}
             </>
           )}
         </div>

--- a/frontend/app/lib/utils/number.ts
+++ b/frontend/app/lib/utils/number.ts
@@ -1,3 +1,5 @@
+import { formatNumberAdvanced } from '@/lib/utils'
+
 /**
  * Formats a number with decimal limits and subscript notation for consecutive zeros
  * @param value The number to format (number, string, or undefined)
@@ -42,4 +44,37 @@ export function formatNumberWithSubscript(
 
   // Combine integer and decimal parts
   return formattedDecimal ? `${integerPart}.${formattedDecimal}` : integerPart
+}
+
+/**
+ * Smart wrapper that decides which formatting function to use based on the number's characteristics
+ * @param value The number to format (number, string, or undefined)
+ * @param maxDecimals Maximum number of decimal places for subscript formatting (default: 5)
+ * @returns Formatted number string, or null if value is undefined
+ *
+ * Logic:
+ * - If number >= 10,000: use formatNumberAdvanced
+ * - If number < 10,000 with significant decimals: use formatNumberWithSubscript
+ */
+export function formatNumberSmart(
+  value: number | string | undefined,
+  maxDecimals: number = 5
+): string | null {
+  if (value === undefined) return null
+
+  const numValue = typeof value === 'string' ? parseFloat(value) : value
+
+  if (isNaN(numValue)) return numValue.toString()
+
+  if (numValue === 0) return '0'
+
+  const absValue = Math.abs(numValue)
+
+  // If the number is >= 10,000, use formatNumberAdvanced
+  if (absValue >= 10000) {
+    return formatNumberAdvanced(numValue)
+  }
+
+  // For numbers < 10,000, use formatNumberWithSubscript
+  return formatNumberWithSubscript(value, maxDecimals)
 }


### PR DESCRIPTION
- Fixing issue with instasettle pill and estimated time/streams completed going onto two lines. 
- Implemented number formatting to handle both subscript and large numbers into one function. 

<img width="358" height="136" alt="image" src="https://github.com/user-attachments/assets/f08b8529-138e-4456-a4fb-7539f8dcbcf5" />
