### PR TITLE
fixing token selection on instasettlepage

### DIFF
--- a/frontend/app/components/instasettle/InstasettleTokenSelector.tsx
+++ b/frontend/app/components/instasettle/InstasettleTokenSelector.tsx
@@ -141,6 +141,33 @@ interface InstasettleTokenSelectorProps {
   onTokenToChange: (token: TOKENS_TYPE | null) => void
 }
 
+// Clear button component for token selectors
+const ClearTokenButton = ({ onClick }: { onClick: () => void }) => (
+  <button
+    onClick={(e) => {
+      e.stopPropagation()
+      onClick()
+    }}
+    className="ml-2 p-1 hover:bg-white/10 rounded-full transition-colors"
+    title="Clear selection"
+  >
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="14"
+      height="14"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <line x1="18" y1="6" x2="6" y2="18"></line>
+      <line x1="6" y1="6" x2="18" y2="18"></line>
+    </svg>
+  </button>
+)
+
 const InstasettleTokenSelector: React.FC<InstasettleTokenSelectorProps> = ({
   onTokenFromChange,
   onTokenToChange,
@@ -168,37 +195,7 @@ const InstasettleTokenSelector: React.FC<InstasettleTokenSelectorProps> = ({
   console.log('availableTokens ==>', availableTokens)
   console.log('jsonTokens ==>', jsonTokens)
 
-  // Auto-select first trade tokens on mount
-  useEffect(() => {
-    if (firstTrade && !fromToken && !toToken && availableTokens.length > 0) {
-      const tokenInAddress = firstTrade.tokenIn.toLowerCase()
-      const tokenOutAddress = firstTrade.tokenOut.toLowerCase()
-
-      const fromTokenMatch = availableTokens.find(
-        (token) => token.token_address.toLowerCase() === tokenInAddress
-      )
-      const toTokenMatch = availableTokens.find(
-        (token) => token.token_address.toLowerCase() === tokenOutAddress
-      )
-
-      if (fromTokenMatch) {
-        setFromToken(fromTokenMatch)
-        onTokenFromChange(fromTokenMatch)
-      }
-
-      if (toTokenMatch) {
-        setToToken(toTokenMatch)
-        onTokenToChange(toTokenMatch)
-      }
-    }
-  }, [
-    firstTrade,
-    availableTokens,
-    fromToken,
-    toToken,
-    onTokenFromChange,
-    onTokenToChange,
-  ])
+  // No longer auto-select tokens on mount - start with no filters to show all trades
 
   const handleTokenSelect = (token: TOKENS_TYPE) => {
     if (currentInputField === 'from') {
@@ -208,6 +205,16 @@ const InstasettleTokenSelector: React.FC<InstasettleTokenSelectorProps> = ({
       setToToken(token)
       onTokenToChange(token)
     }
+  }
+
+  const handleClearFromToken = () => {
+    setFromToken(null)
+    onTokenFromChange(null)
+  }
+
+  const handleClearToToken = () => {
+    setToToken(null)
+    onTokenToChange(null)
   }
 
   const showSelectTokenModal = (isOpen: boolean, field: 'from' | 'to') => {
@@ -248,8 +255,6 @@ const InstasettleTokenSelector: React.FC<InstasettleTokenSelectorProps> = ({
       setBoltConfig(defaultBoltConfig)
     }
   }, [fromToken, toToken])
-
-  const bothTokensSelected = fromToken && toToken
 
   return (
     <>
@@ -314,13 +319,7 @@ const InstasettleTokenSelector: React.FC<InstasettleTokenSelectorProps> = ({
                       </div>
                       <p>{fromToken.symbol || ''}</p>
                     </div>
-                    <Image
-                      src="/icons/arrow-down-white.svg"
-                      alt="close"
-                      className="w-fit h-fit mr-0 sm:mr-4"
-                      width={20}
-                      height={20}
-                    />
+                    <ClearTokenButton onClick={handleClearFromToken} />
                   </div>
                 </div>
               ) : (
@@ -507,13 +506,7 @@ const InstasettleTokenSelector: React.FC<InstasettleTokenSelectorProps> = ({
                       </div>
                       <p>{toToken.symbol || ''}</p>
                     </div>
-                    <Image
-                      src="/icons/arrow-down-white.svg"
-                      alt="close"
-                      className="w-fit h-fit mr-4"
-                      width={20}
-                      height={20}
-                    />
+                    <ClearTokenButton onClick={handleClearToToken} />
                   </div>
                 </div>
               ) : (

--- a/frontend/app/components/instasettle/TradesChart.tsx
+++ b/frontend/app/components/instasettle/TradesChart.tsx
@@ -106,6 +106,7 @@ export default function TradesChart({
     if (!trades || trades.length === 0) return []
 
     // Filter trades based on selected tokens
+    // Start with base filter for instasettlable trades
     let filteredTrades = trades.filter(
       (trade) =>
         (trade.isInstasettlable || trade.onlyInstasettle) &&
@@ -113,17 +114,23 @@ export default function TradesChart({
         trade.cancellations.length === 0
     )
 
-    if (selectedTokenFrom && selectedTokenTo) {
-      filteredTrades = trades.filter(
-        (trade) =>
-          trade.isInstasettlable &&
-          trade.instasettlements.length === 0 &&
-          trade.cancellations.length === 0 &&
-          trade.tokenIn?.toLowerCase() ===
-            selectedTokenFrom.token_address?.toLowerCase() &&
-          trade.tokenOut?.toLowerCase() ===
+    // Apply token filters based on selection state
+    // - Both null: show all trades
+    // - Only from selected: filter by tokenIn
+    // - Only to selected: filter by tokenOut
+    // - Both selected: filter by both tokenIn and tokenOut
+    if (selectedTokenFrom || selectedTokenTo) {
+      filteredTrades = filteredTrades.filter((trade) => {
+        const matchesFrom = selectedTokenFrom
+          ? trade.tokenIn?.toLowerCase() ===
+            selectedTokenFrom.token_address?.toLowerCase()
+          : true
+        const matchesTo = selectedTokenTo
+          ? trade.tokenOut?.toLowerCase() ===
             selectedTokenTo.token_address?.toLowerCase()
-      )
+          : true
+        return matchesFrom && matchesTo
+      })
     }
 
     // Combine real and mock trades
@@ -611,7 +618,19 @@ export default function TradesChart({
 
   // Show no data state
   if (!trades || trades.length === 0 || sortedChartData.length === 0) {
-    const hasTokenFilter = selectedTokenFrom && selectedTokenTo
+    const hasTokenFilter = selectedTokenFrom || selectedTokenTo
+    const getFilterDescription = () => {
+      if (selectedTokenFrom && selectedTokenTo) {
+        return `${selectedTokenFrom.symbol} → ${selectedTokenTo.symbol}`
+      }
+      if (selectedTokenFrom) {
+        return `${selectedTokenFrom.symbol} → Any`
+      }
+      if (selectedTokenTo) {
+        return `Any → ${selectedTokenTo.symbol}`
+      }
+      return ''
+    }
     return (
       <div className="mt-32 mb-16">
         <div className="dark">
@@ -619,7 +638,7 @@ export default function TradesChart({
             <div className="mb-6 flex flex-col md:flex-row gap-4 md:gap-0 justify-between items-center">
               <h2 className="text-2xl font-bold">
                 {hasTokenFilter
-                  ? `No Trades Found for ${selectedTokenFrom.symbol}/${selectedTokenTo.symbol}`
+                  ? `No Trades Found for ${getFilterDescription()}`
                   : 'No Trades Available'}
               </h2>
               <div className="flex gap-2">
@@ -689,7 +708,7 @@ export default function TradesChart({
                 </h3>
                 <p className="text-muted-foreground">
                   {hasTokenFilter
-                    ? `No trades found for the selected token pair ${selectedTokenFrom.symbol}/${selectedTokenTo.symbol}`
+                    ? `No trades found for the selected filter: ${getFilterDescription()}`
                     : 'There are currently no trades to display. Check back later or try selecting different tokens.'}
                 </p>
               </div>
@@ -1008,9 +1027,19 @@ export default function TradesChart({
                       content={({ active, payload, label }) => {
                         if (active && payload && payload.length) {
                           const dataPoint = indexedChartData[Number(label)]
+                          const trade = dataPoint?.trade
+                          const tokenInSymbol =
+                            trade?.tokenInDetails?.symbol || 'Unknown'
+                          const tokenOutSymbol =
+                            trade?.tokenOutDetails?.symbol || 'Unknown'
                           return (
-                            <div className="rounded-lg border border-white005 bg-black p-3 shadow-md">
+                            <div className="rounded-lg border border-white005 bg-black p-3 shadow-md min-w-[180px]">
                               <div className="grid gap-2">
+                                <div className="flex items-center justify-center gap-2 pb-2 border-b border-white005">
+                                  <span className="text-sm font-bold text-primary">
+                                    {tokenInSymbol} → {tokenOutSymbol}
+                                  </span>
+                                </div>
                                 <div className="flex items-center justify-between gap-2">
                                   <span className="text-sm font-medium text-muted-foreground">
                                     Cost:
@@ -1028,6 +1057,25 @@ export default function TradesChart({
                                   </span>
                                   <span className="text-sm font-bold">
                                     ${Number(payload[0].value).toFixed(2)}
+                                  </span>
+                                </div>
+                                <div className="flex items-center justify-between gap-2">
+                                  <span className="text-sm font-medium text-muted-foreground">
+                                    Volume:
+                                  </span>
+                                  <span className="text-sm font-bold">
+                                    {dataPoint
+                                      ? Number(dataPoint.volume).toFixed(4)
+                                      : '0'}{' '}
+                                    {tokenInSymbol}
+                                  </span>
+                                </div>
+                                <div className="flex items-center justify-between gap-2">
+                                  <span className="text-sm font-medium text-muted-foreground">
+                                    BPS:
+                                  </span>
+                                  <span className="text-sm font-bold">
+                                    {trade?.instasettleBps || '0'}
                                   </span>
                                 </div>
                               </div>

--- a/frontend/app/components/instasettle/TradesTable.tsx
+++ b/frontend/app/components/instasettle/TradesTable.tsx
@@ -347,13 +347,21 @@ const TradesTable = ({
       }
     })
 
-    // Apply token filter (only if both tokens are selected and not chart filtered)
-    if (tokenFromAddress && tokenToAddress && !isChartFiltered) {
-      filteredTrades = filteredTrades.filter(
-        (trade) =>
-          trade.tokenIn?.toLowerCase() === tokenFromAddress &&
-          trade.tokenOut?.toLowerCase() === tokenToAddress
-      )
+    // Apply token filter based on selection state (if not chart filtered)
+    // - Both null: show all trades
+    // - Only from selected: filter by tokenIn
+    // - Only to selected: filter by tokenOut
+    // - Both selected: filter by both tokenIn and tokenOut
+    if ((tokenFromAddress || tokenToAddress) && !isChartFiltered) {
+      filteredTrades = filteredTrades.filter((trade) => {
+        const matchesFrom = tokenFromAddress
+          ? trade.tokenIn?.toLowerCase() === tokenFromAddress
+          : true
+        const matchesTo = tokenToAddress
+          ? trade.tokenOut?.toLowerCase() === tokenToAddress
+          : true
+        return matchesFrom && matchesTo
+      })
     }
 
     // Apply ownership filter

--- a/frontend/app/components/landing/gateway-section.tsx
+++ b/frontend/app/components/landing/gateway-section.tsx
@@ -99,12 +99,9 @@ const GatewaySection = () => {
     hover: {
       scale: 1.2,
       transition: {
-        duration: 0.3,
-        ease: 'easeOut',
-        spring: {
-          damping: 10,
-          stiffness: 100,
-        },
+        type: 'spring',
+        damping: 10,
+        stiffness: 100,
       },
     },
   }


### PR DESCRIPTION
### Summary

Updated the instasettle page to allow for more advanced filtering of tokens.

### Changes

- removed initial token being selected
- Allowed clearing of both tokens
- Allowed setting both tokens individually and together:
    - Both null: show all trades
    - Only from selected: filter by tokenIn
    - Only to selected: filter by tokenOut
    - Both selected: filter by both tokenIn and tokenOut